### PR TITLE
Add method to get filenames for auditing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,14 @@ client.fetch_warcs(
   crawl_start_before: '2023-01-31'
 )
 
-# Fetch a single WARC with a URL
+# Get filenames for a collection (used when auditing)
+client.filenames(
+  collection: '12345',
+  crawl_start_after: '2025-01-01',
+  crawl_start_before: '2025-06-30'
+)
+
+# Fetch a single WARC by URL
 client.fetch_file(
   file: 'https://warcs.archive-it.org/webdatafile/ARCHIVEIT-123-example.warc.gz',
   output_dir: 'path/to/save/warcs'

--- a/lib/wasapi_client.rb
+++ b/lib/wasapi_client.rb
@@ -96,6 +96,16 @@ class WasapiClient
     download(url: file, output_dir:)
   end
 
+  # Send a GET request for WARCs filenames.
+  # @param collection [String] the Archive-It collection ID
+  # @param crawl_start_after [String] the start date for the crawl in RFC3339 format
+  # @param crawl_start_before [String] the end date for the crawl in RFC3339 format
+  # @return [Array<String>] WARC filenames
+  def filenames(collection:, crawl_start_after: nil, crawl_start_before: nil)
+    locations = get_locations(collection:, crawl_start_after:, crawl_start_before:)
+    locations.map { |location| File.basename(location[:url]) }
+  end
+
   private
 
   # Extract the WARC file locations and checksums from the response while paginating through results

--- a/spec/wasapi_client_spec.rb
+++ b/spec/wasapi_client_spec.rb
@@ -308,4 +308,16 @@ RSpec.describe WasapiClient do
       end
     end
   end
+
+  describe '.filenames' do
+    it 'returns filenames for a collection and date range' do
+      filenames = client.filenames(
+        collection: collection_id,
+        crawl_start_after: crawl_start_after,
+        crawl_start_before: crawl_start_before
+      )
+
+      expect(filenames).to eq(['warc1.warc.gz', 'warc2.warc.gz'])
+    end
+  end
 end


### PR DESCRIPTION
Adds a method to retrieve WARC filenames, to support auditing in Was Registrar App: https://github.com/sul-dlss/was-registrar-app/blob/main/app/services/audit/wasapi_warc_lister.rb